### PR TITLE
Add Paid Ads Conversions

### DIFF
--- a/models/marts/marketing/paid_ads__ad_report_enriched.sql
+++ b/models/marts/marketing/paid_ads__ad_report_enriched.sql
@@ -7,7 +7,7 @@
 {% set conversions_field = var('conversions_field', 'count_pageviews') %}
 {% set excluded_landing_page_hostnames = var('excluded_landing_page_hostnames', []) %}
 
-with paid_ads as (
+with ad_report as (
     select
         date_day,
         platform,
@@ -15,14 +15,46 @@ with paid_ads as (
         campaign_name as campaign,
         ad_group_name as ad_group,
         ad_name as ad,
+        ad_id,
         cast(null as {{ dbt.type_string() }}) as session_source,
         cast(null as {{ dbt.type_string() }}) as session_medium,
         clicks,
         impressions,
-        spend,
-        null as conversions,
-        null as revenue
+        spend
     from {{ref('ad_reporting__ad_report')}} 
+),
+google_ads_ad_conversions as (
+    select
+        date_day,
+        cast(ad_id as {{ dbt.type_string() }}) as ad_id,
+        sum(conversions) as platform_conversions,
+        sum(conversions_value) as platform_conversions_value
+    from {{ ref('google_ads__ad_report') }}
+    group by 1, 2
+),
+paid_ads as (
+    select
+        ad_report.date_day,
+        ad_report.platform,
+        ad_report.account,
+        ad_report.campaign,
+        ad_report.ad_group,
+        ad_report.ad,
+        ad_report.session_source,
+        ad_report.session_medium,
+        ad_report.clicks,
+        ad_report.impressions,
+        ad_report.spend,
+        gac.platform_conversions,
+        gac.platform_conversions_value,
+        cast(null as float64) as ga4_session_conversions,
+        cast(null as float64) as ga4_session_revenue,
+        cast(null as float64) as ga4_last_non_direct_conversions,
+        cast(null as float64) as ga4_last_non_direct_revenue
+    from ad_report
+    left join google_ads_ad_conversions gac
+        on ad_report.ad_id = gac.ad_id
+        and ad_report.date_day = gac.date_day
 ),
 ga4_sessions_with_purchases as (
     select 
@@ -37,8 +69,12 @@ ga4_sessions_with_purchases as (
         null as clicks,
         null as impressions,
         null as spend,
-        {{ conversions_field }} as conversions,
-        sum_event_value_in_usd as revenue
+        cast(null as float64) as platform_conversions,
+        cast(null as float64) as platform_conversions_value,
+        {{ conversions_field }} as ga4_session_conversions,
+        sum_event_value_in_usd as ga4_session_revenue,
+        cast(null as float64) as ga4_last_non_direct_conversions,
+        cast(null as float64) as ga4_last_non_direct_revenue
     from {{ ref('ga4__sessions') }}
     where {{ conversions_field }} > 0
     {% if excluded_landing_page_hostnames | length > 0 %}
@@ -50,10 +86,45 @@ ga4_sessions_with_purchases as (
              ))
     {% endif %}
 ),
+ga4_last_non_direct_sessions_with_purchases as (
+    select
+        fct.session_partition_date as date_day,
+        cast(null as {{ dbt.type_string() }}) as platform,
+        cast(null as {{ dbt.type_string() }}) as account,
+        dim.last_non_direct_campaign as campaign,
+        cast(null as {{ dbt.type_string() }}) as ad_group,
+        cast(null as {{ dbt.type_string() }}) as ad,
+        dim.last_non_direct_source as session_source,
+        dim.last_non_direct_medium as session_medium,
+        null as clicks,
+        null as impressions,
+        null as spend,
+        cast(null as float64) as platform_conversions,
+        cast(null as float64) as platform_conversions_value,
+        cast(null as float64) as ga4_session_conversions,
+        cast(null as float64) as ga4_session_revenue,
+        fct.purchase_count as ga4_last_non_direct_conversions,
+        fct.session_partition_sum_event_value_in_usd as ga4_last_non_direct_revenue
+    from {{ ref('fct_ga4__sessions_daily') }} fct
+    inner join {{ ref('dim_ga4__sessions_daily') }} dim
+        on fct.session_partition_key = dim.session_partition_key
+    where fct.purchase_count > 0
+        and dim.last_non_direct_source != '(direct)'
+    {% if excluded_landing_page_hostnames | length > 0 %}
+        and (dim.landing_page_location is null 
+             or NET.HOST(dim.landing_page_location) not in (
+                 {%- for hostname in excluded_landing_page_hostnames -%}
+                     '{{ hostname }}'{% if not loop.last %},{% endif %}
+                 {%- endfor -%}
+             ))
+    {% endif %}
+),
 final as (
     select * from paid_ads
     union all
     select * from ga4_sessions_with_purchases
+    union all
+    select * from ga4_last_non_direct_sessions_with_purchases
 )
 
 select * from final

--- a/models/marts/marketing/paid_ads__campaign_report_enriched.sql
+++ b/models/marts/marketing/paid_ads__campaign_report_enriched.sql
@@ -19,10 +19,17 @@ with paid_ads as (
         clicks,
         impressions,
         spend,
-        null as conversions,
-        null as revenue,
         null as sessions
     from {{ref('ad_reporting__campaign_report')}} 
+),
+google_ads_conversions as (
+    select
+        date_day,
+        cast(campaign_id as {{ dbt.type_string() }}) as campaign_id,
+        sum(conversions) as platform_conversions,
+        sum(conversions_value) as platform_conversions_value
+    from {{ ref('google_ads__campaign_report') }}
+    group by 1, 2
 ),
 ga4_sessions_aggregated as (
     select 
@@ -33,8 +40,8 @@ ga4_sessions_aggregated as (
             else session_source
         end) as session_source,
         max(session_medium) as session_medium,
-        sum(case when {{ conversions_field }} > 0 then {{ conversions_field }} else 0 end) as conversions,
-        sum(case when {{ conversions_field }} > 0 then sum_event_value_in_usd else 0 end) as revenue,
+        sum(case when {{ conversions_field }} > 0 then {{ conversions_field }} else 0 end) as ga4_session_conversions,
+        sum(case when {{ conversions_field }} > 0 then sum_event_value_in_usd else 0 end) as ga4_session_revenue,
         sum(sessions) as sessions
     from {{ ref('ga4__sessions') }}
     where 1=1
@@ -46,6 +53,36 @@ ga4_sessions_aggregated as (
                  {%- endfor -%}
              ))
     {% endif %}
+    group by 1, 2
+),
+ga4_last_non_direct_sessions as (
+    select
+        fct.session_partition_date as date_day,
+        {{ get_query_parameter_value('dim.landing_page_location', 'utm_id') }} as campaign_id,
+        dim.last_non_direct_source,
+        dim.last_non_direct_medium,
+        fct.session_partition_sum_event_value_in_usd,
+        fct.purchase_count
+    from {{ ref('fct_ga4__sessions_daily') }} fct
+    inner join {{ ref('dim_ga4__sessions_daily') }} dim
+        on fct.session_partition_key = dim.session_partition_key
+    where dim.last_non_direct_source != '(direct)'
+    {% if excluded_landing_page_hostnames | length > 0 %}
+        and (dim.landing_page_location is null 
+             or NET.HOST(dim.landing_page_location) not in (
+                 {%- for hostname in excluded_landing_page_hostnames -%}
+                     '{{ hostname }}'{% if not loop.last %},{% endif %}
+                 {%- endfor -%}
+             ))
+    {% endif %}
+),
+ga4_last_non_direct_conversions as (
+    select
+        date_day,
+        campaign_id,
+        sum(case when purchase_count > 0 then purchase_count else 0 end) as ga4_last_non_direct_conversions,
+        sum(case when purchase_count > 0 then session_partition_sum_event_value_in_usd else 0 end) as ga4_last_non_direct_revenue
+    from ga4_last_non_direct_sessions
     group by 1, 2
 ),
 final as (
@@ -60,14 +97,26 @@ final as (
         paid_ads.clicks,
         paid_ads.impressions,
         paid_ads.spend,
-        ga4_sessions_aggregated.conversions,
-        ga4_sessions_aggregated.revenue,
+        google_ads_conversions.platform_conversions,
+        google_ads_conversions.platform_conversions_value,
+        ga4_sessions_aggregated.ga4_session_conversions,
+        ga4_sessions_aggregated.ga4_session_revenue,
+        ga4_last_non_direct_conversions.ga4_last_non_direct_conversions,
+        ga4_last_non_direct_conversions.ga4_last_non_direct_revenue,
         ga4_sessions_aggregated.sessions
     from paid_ads
+
+    left join google_ads_conversions
+        on paid_ads.campaign_id = google_ads_conversions.campaign_id
+        and paid_ads.date_day = google_ads_conversions.date_day
 
     left join ga4_sessions_aggregated
         on paid_ads.campaign_id = ga4_sessions_aggregated.campaign_id
         and paid_ads.date_day = ga4_sessions_aggregated.date_day
+
+    left join ga4_last_non_direct_conversions
+        on paid_ads.campaign_id = ga4_last_non_direct_conversions.campaign_id
+        and paid_ads.date_day = ga4_last_non_direct_conversions.date_day
 )
 
 select * from final


### PR DESCRIPTION
**Branch:** `feat/add-paid-ads-conversions`
**Target:** `main`

## Summary

This PR adds multi-attribution conversion columns to the paid ads enriched models, bringing together **platform-reported conversions** (Google Ads), **GA4 session-scoped conversions**, and **GA4 last-non-direct attributed conversions** into a single reporting layer.

## Source Verification

| Platform | Conversions Available | Notes |
|---|---|---|
| **Google Ads** (`ad_stats`, `campaign_stats`) | `conversions`, `conversions_value`, `view_through_conversions` | Fully supported in this PR |
| **Facebook Ads** (`basic_ad`) | No `conversions` column | Facebook stores conversions in separate `basic_ad_actions` / `basic_ad_action_values` tables, which the current Fivetran Facebook Ads package does not surface. Platform conversions for Facebook will be addressed as a follow-up. |

## Changes

### `paid_ads__campaign_report_enriched.sql`

- **Platform conversions:** Added a `google_ads_conversions` CTE that aggregates `conversions` and `conversions_value` from `google_ads__campaign_report`, joined to paid ads on `campaign_id` + `date_day`.
- **GA4 session conversions:** Renamed from `conversions` / `revenue` to `ga4_session_conversions` / `ga4_session_revenue` for clarity.
- **GA4 LND conversions:** Added `ga4_last_non_direct_sessions` and `ga4_last_non_direct_conversions` CTEs that join `fct_ga4__sessions_daily` with `dim_ga4__sessions_daily` (which carries LND attribution), filtering to non-direct LND sessions, then aggregating by `campaign_id` + `date_day`.

### `paid_ads__ad_report_enriched.sql`

- **Platform conversions:** Added a `google_ads_ad_conversions` CTE joined to the paid ads data on `ad_id` + `date_day`.
- **GA4 session conversions:** Renamed to `ga4_session_conversions` / `ga4_session_revenue` for consistency with the campaign model.
- **GA4 LND conversions:** Added `ga4_last_non_direct_sessions_with_purchases` CTE as a new `UNION ALL` segment with last-non-direct-attributed purchases.

## New Columns

Both enriched models now expose the following conversion columns:

| Column | Source |
|---|---|
| `platform_conversions` | Google Ads reported conversions |
| `platform_conversions_value` | Google Ads reported conversion value |
| `ga4_session_conversions` | GA4 session-attributed conversions (formerly `conversions`) |
| `ga4_session_revenue` | GA4 session-attributed revenue (formerly `revenue`) |
| `ga4_last_non_direct_conversions` | GA4 last-non-direct attributed conversions |
| `ga4_last_non_direct_revenue` | GA4 last-non-direct attributed revenue |

## Model Architecture

### Campaign Report (`paid_ads__campaign_report_enriched`)

Uses a **join-based** approach — paid ads, Google Ads conversions, GA4 session aggregates, and GA4 LND conversions are all joined on `campaign_id` + `date_day` in the `final` CTE, producing one row per campaign per day.

### Ad Report (`paid_ads__ad_report_enriched`)

Uses a **union-based** approach — separate CTEs for paid ads (with platform conversions joined), GA4 session-level purchases, and GA4 LND-attributed purchases are combined via `UNION ALL`, producing granular rows by attribution source.

## Follow-up Items

- [ ] Surface Facebook Ads platform conversions once `basic_ad_actions` / `basic_ad_action_values` are available via the Fivetran package
- [ ] Consider adding `view_through_conversions` from Google Ads as a separate column
