### PR TITLE
feat: add Meta and Microsoft Ads platform_conversions to enriched models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'sys_dbt_ga4'
-version: '1.0.1'
+version: '1.0.19'
 config-version: 2
 model-paths: ["models"]
 analysis-paths: ["analyses"]
@@ -28,6 +28,8 @@ vars:
   # Filter out sessions where landing page hostname matches any in this list
   # Example: excluded_landing_page_hostnames: ["www.domain.com"]
   excluded_landing_page_hostnames: []
+  enable_meta_platform_conversions: false
+  enable_microsoft_platform_conversions: false
   # mapping_dataset: 
   # mapping_table: 
   # ad_reporting__ad_report: "{{ ref('ad_reporting__ad_report') }}"

--- a/models/marts/marketing/paid_ads__ad_report_enriched.sql
+++ b/models/marts/marketing/paid_ads__ad_report_enriched.sql
@@ -32,6 +32,17 @@ google_ads_ad_conversions as (
     from {{ ref('google_ads__ad_report') }}
     group by 1, 2
 ),
+{% if var('enable_meta_platform_conversions', false) %}
+meta_ads_ad_conversions as (
+    select
+        date_day,
+        cast(ad_id as {{ dbt.type_string() }}) as ad_id,
+        sum(conversions) as platform_conversions,
+        sum(conversions_value) as platform_conversions_value
+    from {{ ref('facebook_ads__ad_report') }}
+    group by 1, 2
+),
+{% endif %}
 paid_ads as (
     select
         ad_report.date_day,
@@ -45,8 +56,18 @@ paid_ads as (
         ad_report.clicks,
         ad_report.impressions,
         ad_report.spend,
-        gac.platform_conversions,
-        gac.platform_conversions_value,
+        coalesce(
+            gac.platform_conversions
+            {% if var('enable_meta_platform_conversions', false) %}
+            , mac.platform_conversions
+            {% endif %}
+        ) as platform_conversions,
+        coalesce(
+            gac.platform_conversions_value
+            {% if var('enable_meta_platform_conversions', false) %}
+            , mac.platform_conversions_value
+            {% endif %}
+        ) as platform_conversions_value,
         cast(null as float64) as ga4_session_conversions,
         cast(null as float64) as ga4_session_revenue,
         cast(null as float64) as ga4_last_non_direct_conversions,
@@ -55,6 +76,11 @@ paid_ads as (
     left join google_ads_ad_conversions gac
         on ad_report.ad_id = gac.ad_id
         and ad_report.date_day = gac.date_day
+    {% if var('enable_meta_platform_conversions', false) %}
+    left join meta_ads_ad_conversions mac
+        on ad_report.ad_id = mac.ad_id
+        and ad_report.date_day = mac.date_day
+    {% endif %}
 ),
 ga4_sessions_with_purchases as (
     select 

--- a/models/marts/marketing/paid_ads__campaign_report_enriched.sql
+++ b/models/marts/marketing/paid_ads__campaign_report_enriched.sql
@@ -31,6 +31,28 @@ google_ads_conversions as (
     from {{ ref('google_ads__campaign_report') }}
     group by 1, 2
 ),
+{% if var('enable_meta_platform_conversions', false) %}
+meta_ads_conversions as (
+    select
+        date_day,
+        cast(campaign_id as {{ dbt.type_string() }}) as campaign_id,
+        sum(conversions) as platform_conversions,
+        sum(conversions_value) as platform_conversions_value
+    from {{ ref('facebook_ads__campaign_report') }}
+    group by 1, 2
+),
+{% endif %}
+{% if var('enable_microsoft_platform_conversions', false) %}
+microsoft_ads_conversions as (
+    select
+        date_day,
+        cast(campaign_id as {{ dbt.type_string() }}) as campaign_id,
+        sum(conversions) as platform_conversions,
+        sum(conversions_value) as platform_conversions_value
+    from {{ ref('microsoft_ads__campaign_report') }}
+    group by 1, 2
+),
+{% endif %}
 ga4_sessions_aggregated as (
     select 
         session_start_date as date_day,
@@ -97,8 +119,24 @@ final as (
         paid_ads.clicks,
         paid_ads.impressions,
         paid_ads.spend,
-        google_ads_conversions.platform_conversions,
-        google_ads_conversions.platform_conversions_value,
+        coalesce(
+            google_ads_conversions.platform_conversions
+            {% if var('enable_meta_platform_conversions', false) %}
+            , meta_ads_conversions.platform_conversions
+            {% endif %}
+            {% if var('enable_microsoft_platform_conversions', false) %}
+            , microsoft_ads_conversions.platform_conversions
+            {% endif %}
+        ) as platform_conversions,
+        coalesce(
+            google_ads_conversions.platform_conversions_value
+            {% if var('enable_meta_platform_conversions', false) %}
+            , meta_ads_conversions.platform_conversions_value
+            {% endif %}
+            {% if var('enable_microsoft_platform_conversions', false) %}
+            , microsoft_ads_conversions.platform_conversions_value
+            {% endif %}
+        ) as platform_conversions_value,
         ga4_sessions_aggregated.ga4_session_conversions,
         ga4_sessions_aggregated.ga4_session_revenue,
         ga4_last_non_direct_conversions.ga4_last_non_direct_conversions,
@@ -109,6 +147,18 @@ final as (
     left join google_ads_conversions
         on paid_ads.campaign_id = google_ads_conversions.campaign_id
         and paid_ads.date_day = google_ads_conversions.date_day
+
+    {% if var('enable_meta_platform_conversions', false) %}
+    left join meta_ads_conversions
+        on paid_ads.campaign_id = meta_ads_conversions.campaign_id
+        and paid_ads.date_day = meta_ads_conversions.date_day
+    {% endif %}
+
+    {% if var('enable_microsoft_platform_conversions', false) %}
+    left join microsoft_ads_conversions
+        on paid_ads.campaign_id = microsoft_ads_conversions.campaign_id
+        and paid_ads.date_day = microsoft_ads_conversions.date_day
+    {% endif %}
 
     left join ga4_sessions_aggregated
         on paid_ads.campaign_id = ga4_sessions_aggregated.campaign_id


### PR DESCRIPTION
Add platform_conversions from facebook_ads and microsoft_ads packages to the paid_ads enriched models. Previously only Google Ads conversions were joined; Meta and Microsoft rows had null platform_conversions.

Campaign-level: adds Meta + Microsoft conversion CTEs/joins
Ad-level: adds Meta conversion CTE/join (Microsoft not needed at ad level)

New opt-in variables (default false):
- enable_meta_platform_conversions: requires facebook_ads package v1.3.0+
- enable_microsoft_platform_conversions: requires microsoft_ads passthrough metrics

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
