### PR TITLE
Fix GA4 last-non-direct campaign attribution

### DIFF
--- a/models/marts/google_analytics_4/_ga4_models.yml
+++ b/models/marts/google_analytics_4/_ga4_models.yml
@@ -6,6 +6,13 @@ models:
     config:
       schema: marts_google_analytics_4
       materialized: table
+    columns:
+      - name: landing_page_location
+        description: >
+          First non-null page_location across the session's events (FIRST_VALUE ... IGNORE NULLS),
+          mirroring dim_ga4__sessions_daily. Used as the source for query-parameter extraction
+          (session_utm_id, session_ad_id, session_ad_group_id) so campaign attribution is not lost
+          when the first session event has no URL. Falls back to landing_page when null.
 
 
 

--- a/models/marts/google_analytics_4/ga4__sessions.sql
+++ b/models/marts/google_analytics_4/ga4__sessions.sql
@@ -25,6 +25,24 @@ session_first_event as
     and event_name != 'session_start'
     qualify row_number() over(partition by session_key order by event_timestamp) = 1
 ),
+session_landing_page as
+(
+    -- Complete landing page: first NON-NULL page_location across the session,
+    -- mirroring dim_ga4__sessions_daily (FIRST_VALUE ... IGNORE NULLS). The package's
+    -- non-daily dim_ga4__sessions.landing_page uses the first event's page_location as-is,
+    -- which is NULL when that event has no URL, dropping campaign attribution downstream.
+    select
+        session_key,
+        first_value(page_location ignore nulls) over (
+            partition by session_key
+            order by event_timestamp
+            rows between unbounded preceding and unbounded following
+        ) as landing_page_location
+    from {{ref('stg_ga4__events')}}
+    where event_name != 'first_visit'
+    and event_name != 'session_start'
+    qualify row_number() over(partition by session_key order by event_timestamp) = 1
+),
 ga4_sessions as(
     select
             fct_ga4_sessions.*,
@@ -42,7 +60,8 @@ ga4_sessions as(
                 when session_source = "fb" then "facebook"
                 else session_source
             end as session_source,
-            {{ conversions_field }} as conversions
+            {{ conversions_field }} as conversions,
+            session_landing_page.landing_page_location as landing_page_location
     from fct_ga4_sessions
     left join dim_sessions 
         on fct_ga4_sessions.session_key = dim_sessions.session_key
@@ -52,13 +71,15 @@ ga4_sessions as(
         and fct_ga4_sessions.session_number = dim_sessions.session_number
     left join session_first_event
         on session_first_event.session_key = fct_ga4_sessions.session_key
+    left join session_landing_page
+        on session_landing_page.session_key = fct_ga4_sessions.session_key
 ),
 {% if var('query_parameter_extraction', none) != none %}
     add_query_params as (
         select
             *,
             {%- for param in var('query_parameter_extraction') -%}
-                {{ get_query_parameter_value( 'landing_page' , param ) }} as {{"session_"+param}}
+                {{ get_query_parameter_value( 'coalesce(landing_page_location, landing_page)' , param ) }} as {{"session_"+param}}
                 {% if not loop.last %},{% endif %}
             {%- endfor -%}
         from ga4_sessions

--- a/models/marts/marketing/paid_ads__ad_report_enriched.sql
+++ b/models/marts/marketing/paid_ads__ad_report_enriched.sql
@@ -112,16 +112,38 @@ ga4_sessions_with_purchases as (
              ))
     {% endif %}
 ),
+session_landing_lookup as (
+    -- Params parsed from each session's landing page, used to resolve the campaign/ad/ad_group
+    -- of the LAST NON-DIRECT touch via the lookback pointer (mirrors ga4__sessions extraction).
+    select
+        session_partition_key,
+        landing_page_location,
+        {{ get_query_parameter_value('landing_page_location', 'utm_id') }} as session_utm_id,
+        {{ get_query_parameter_value('landing_page_location', 'ad_id') }} as session_ad_id,
+        {{ get_query_parameter_value('landing_page_location', 'ad_group_id') }} as session_ad_group_id
+    from {{ ref('dim_ga4__sessions_daily') }}
+),
+campaign_mapping as (
+    select * from {{ ref('stg_ads__campaign_mapping') }}
+),
+ad_group_mapping as (
+    select * from {{ ref('stg_ads__ad_group_mapping') }}
+),
+ad_mapping as (
+    select * from {{ ref('stg_ads__ad_mapping') }}
+),
 ga4_last_non_direct_sessions_with_purchases as (
     select
         fct.session_partition_date as date_day,
         cast(null as {{ dbt.type_string() }}) as platform,
         cast(null as {{ dbt.type_string() }}) as account,
-        dim.last_non_direct_campaign as campaign,
-        cast(null as {{ dbt.type_string() }}) as ad_group,
-        cast(null as {{ dbt.type_string() }}) as ad,
-        dim.last_non_direct_source as session_source,
-        dim.last_non_direct_medium as session_medium,
+        -- Campaign/ad/ad_group of the LAST NON-DIRECT touch (the prior session), mapped to
+        -- names so these rows align with the paid_ads and session segments.
+        coalesce(campaign_mapping.campaign_name, lnd.last_non_direct_campaign) as campaign,
+        ad_group_mapping.ad_group_name as ad_group,
+        ad_mapping.ad_name as ad,
+        lnd.last_non_direct_source as session_source,
+        lnd.last_non_direct_medium as session_medium,
         null as clicks,
         null as impressions,
         null as spend,
@@ -132,13 +154,18 @@ ga4_last_non_direct_sessions_with_purchases as (
         fct.purchase_count as ga4_last_non_direct_conversions,
         fct.session_partition_sum_event_value_in_usd as ga4_last_non_direct_revenue
     from {{ ref('fct_ga4__sessions_daily') }} fct
-    inner join {{ ref('dim_ga4__sessions_daily') }} dim
-        on fct.session_partition_key = dim.session_partition_key
+    inner join {{ ref('stg_ga4__sessions_traffic_sources_last_non_direct_daily') }} lnd
+        on fct.session_partition_key = lnd.session_partition_key
+    inner join session_landing_lookup prior
+        on prior.session_partition_key = lnd.session_partition_key_last_non_direct
+    left join campaign_mapping on campaign_mapping.campaign_id = prior.session_utm_id
+    left join ad_group_mapping on ad_group_mapping.ad_group_id = prior.session_ad_group_id
+    left join ad_mapping on ad_mapping.ad_id = prior.session_ad_id
     where fct.purchase_count > 0
-        and dim.last_non_direct_source != '(direct)'
+        and lnd.last_non_direct_source != '(direct)'
     {% if excluded_landing_page_hostnames | length > 0 %}
-        and (dim.landing_page_location is null 
-             or NET.HOST(dim.landing_page_location) not in (
+        and (prior.landing_page_location is null 
+             or NET.HOST(prior.landing_page_location) not in (
                  {%- for hostname in excluded_landing_page_hostnames -%}
                      '{{ hostname }}'{% if not loop.last %},{% endif %}
                  {%- endfor -%}

--- a/models/marts/marketing/paid_ads__campaign_report_enriched.sql
+++ b/models/marts/marketing/paid_ads__campaign_report_enriched.sql
@@ -77,21 +77,35 @@ ga4_sessions_aggregated as (
     {% endif %}
     group by 1, 2
 ),
+session_landing_lookup as (
+    -- One row per session-partition with the UTM id parsed from that session's landing page.
+    -- Used to resolve the campaign of the LAST NON-DIRECT touch via the lookback pointer.
+    select
+        session_partition_key,
+        landing_page_location,
+        {{ get_query_parameter_value('landing_page_location', 'utm_id') }} as campaign_id
+    from {{ ref('dim_ga4__sessions_daily') }}
+),
 ga4_last_non_direct_sessions as (
     select
         fct.session_partition_date as date_day,
-        {{ get_query_parameter_value('dim.landing_page_location', 'utm_id') }} as campaign_id,
-        dim.last_non_direct_source,
-        dim.last_non_direct_medium,
+        -- Campaign id of the LAST NON-DIRECT session (the prior touch), not the
+        -- converting session's own landing page. For self-attributed sessions
+        -- (the converting session is the last non-direct touch) this is unchanged.
+        prior.campaign_id as campaign_id,
+        lnd.last_non_direct_source,
+        lnd.last_non_direct_medium,
         fct.session_partition_sum_event_value_in_usd,
         fct.purchase_count
     from {{ ref('fct_ga4__sessions_daily') }} fct
-    inner join {{ ref('dim_ga4__sessions_daily') }} dim
-        on fct.session_partition_key = dim.session_partition_key
-    where dim.last_non_direct_source != '(direct)'
+    inner join {{ ref('stg_ga4__sessions_traffic_sources_last_non_direct_daily') }} lnd
+        on fct.session_partition_key = lnd.session_partition_key
+    inner join session_landing_lookup prior
+        on prior.session_partition_key = lnd.session_partition_key_last_non_direct
+    where lnd.last_non_direct_source != '(direct)'
     {% if excluded_landing_page_hostnames | length > 0 %}
-        and (dim.landing_page_location is null 
-             or NET.HOST(dim.landing_page_location) not in (
+        and (prior.landing_page_location is null 
+             or NET.HOST(prior.landing_page_location) not in (
                  {%- for hostname in excluded_landing_page_hostnames -%}
                      '{{ hostname }}'{% if not loop.last %},{% endif %}
                  {%- endfor -%}

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,0 +1,8 @@
+packages:
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.0.0
+  - name: ga4
+    package: Velir/ga4
+    version: 6.0.2
+sha1_hash: 22abdad3ae8cbeb0a194d64348218f2397824e6a


### PR DESCRIPTION
```
CI selection:
[ ] Slim CI (default, file-scoped change)
[x] Full CI (touches the shared ga4__sessions model consumed by multiple downstream marts)
```

## Summary

- Fix last-non-direct (LND) campaign attribution in `paid_ads__campaign_report_enriched` and
  `paid_ads__ad_report_enriched`: the LND `campaign_id` was parsed from the **converting
  session's own** landing page, not the **last-non-direct touch**. It now follows
  `session_partition_key_last_non_direct` back to the prior session's landing page.
- Fix a session-conversion **undercount** in `ga4__sessions`: `session_utm_id` is parsed from
  `landing_page`, which is `NULL` for a large and growing share of sessions since 2026-01, so
  those purchases drop out of paid attribution. We now derive a complete
  `landing_page_location` (`FIRST_VALUE(page_location IGNORE NULLS)` across the session) and
  parse query params from `coalesce(landing_page_location, landing_page)`.
- Net effect on paid campaigns: session conversions recover ~+100/month in 2026 (e.g. May
  463 → 564); LND conversions rise modestly every month (e.g. May 563 → 571) and now reflect
  true last-non-direct credit instead of a coincidental "more-complete session" metric.
- No fan-out: the LND lookback join is 1:1 (260,666 rows / 260,666 distinct session-partitions
  for May).

## Grain and scope

- Grain: `ga4__sessions` — one row per session (`surrogate_key`). `paid_ads__campaign_report_enriched`
  — one row per `date_day` × campaign. `paid_ads__ad_report_enriched` — one row per `date_day`
  × platform × account × campaign × ad_group × ad.
- In scope: `models/marts/google_analytics_4/ga4__sessions.sql`,
  `models/marts/marketing/paid_ads__campaign_report_enriched.sql`,
  `models/marts/marketing/paid_ads__ad_report_enriched.sql`, and `_ga4_models.yml` (column doc).
- Out of scope: the Velir `ga4` package internals (unchanged — we read its
  `dim/fct_ga4__sessions_daily` and `stg_ga4__sessions_traffic_sources_last_non_direct_daily`
  as-is); Shopify/order revenue marts; the `(direct)` exclusion semantics (kept).

## Validation evidence

- Spot-check window: closed month **2026-05** (and the full 2023-06 → 2026-06 history below).
  The "before" reproduction matches the live prod mart **to the row** every month
  (e.g. 2026-05 session 463/463, LND 563/563; 2026-01 session 2,084/2,084, LND 2,161/2,161),
  which proves the reproduction is faithful before measuring the "after" delta.
- Reconciliation result: matched on the "before" side; "after" reflects the intended fix.
  See Discrepancies for the one expected drift (live data moved since the last mart build).
- **dbt dev build (done):** the three models were built on GR's **dev** target (`dev_marts`,
  `dev_marts_marketing`), deferring upstreams to prod (`--defer --state <prod manifest>`). They
  **compile, build, and pass tests** (`PASS=7 WARN=1 ERROR=0`; the warning is a `date_day`
  recency check, expected for a dev build). The cross-table test
  `enriched_sessions_count ≈ ga4__sessions count` passed. Dev-vs-prod then reconciled **to the
  row** on every month with complete source data (2023-06 → 2026-02): identical LND deltas
  (+28, +45, … +200, +30, +27) and session deltas (2026-01 +102, 2026-02 +167) — independently
  reproducing the hand-SQL "after" numbers below. See Discrepancy 4 for recent-month freshness.
- Recommended human cross-check before merge: confirm the 2026 monthly uplift against the GA4
  UI (Advertising → Attribution / Traffic acquisition, "Session campaign" vs "Session manual
  campaign id") for one closed month.

**BigQuery SQL (required) — copy-paste reproducible:**

```sql
-- 1) LAST-NON-DIRECT conversions: before (current-session UTM) vs after (prior-touch UTM)
with paid as (
  select distinct campaign_id, date_day
  from `gr-datalake-prod.prod_marts_marketing.paid_ads__campaign_report_enriched`
  where campaign_id is not null
),
slu as (  -- UTM parsed from each session-partition's landing page
  select session_partition_key,
    regexp_extract(landing_page_location, r'utm_id=([^&|\?|#]*)') as camp
  from `gr-datalake-prod.prod_stg_google_analytics_4_core.dim_ga4__sessions_daily`
),
lnd as (
  select
    fct.session_partition_date as date_day,
    fct.purchase_count as conv,
    fct.session_partition_sum_event_value_in_usd as rev,
    cur.camp   as camp_before,   -- old code: converting session's own landing page
    prior.camp as camp_after     -- new code: last-non-direct touch's landing page
  from `gr-datalake-prod.prod_stg_google_analytics_4_core.fct_ga4__sessions_daily` fct
  inner join `gr-datalake-prod.prod_stg_google_analytics_4.stg_ga4__sessions_traffic_sources_last_non_direct_daily` lndstg
    on fct.session_partition_key = lndstg.session_partition_key
  inner join slu cur   on cur.session_partition_key   = fct.session_partition_key
  inner join slu prior on prior.session_partition_key = lndstg.session_partition_key_last_non_direct
  where lndstg.last_non_direct_source != '(direct)' and fct.purchase_count > 0
),
bef as (
  select format_date('%Y-%m', l.date_day) as month, sum(l.conv) as c, round(sum(l.rev),0) as r
  from lnd l inner join paid p on p.campaign_id = l.camp_before and p.date_day = l.date_day group by 1
),
aft as (
  select format_date('%Y-%m', l.date_day) as month, sum(l.conv) as c, round(sum(l.rev),0) as r
  from lnd l inner join paid p on p.campaign_id = l.camp_after and p.date_day = l.date_day group by 1
)
select coalesce(bef.month, aft.month) as month,
  coalesce(bef.c,0) as lnd_conv_before, coalesce(aft.c,0) as lnd_conv_after,
  coalesce(aft.c,0)-coalesce(bef.c,0) as conv_delta,
  coalesce(bef.r,0) as lnd_rev_before, coalesce(aft.r,0) as lnd_rev_after
from bef full outer join aft using (month) order by 1;
```

```sql
-- 2) SESSION conversions: before (= live prod session_utm_id) vs after (complete landing page)
with paid as (
  select distinct campaign_id, date_day
  from `gr-datalake-prod.prod_marts_marketing.paid_ads__campaign_report_enriched`
  where campaign_id is not null
),
clp as (  -- complete landing page per session (entry partition, IGNORE NULLS)
  select session_key,
    array_agg(landing_page_location ignore nulls
              order by session_partition_start_timestamp limit 1)[safe_offset(0)] as complete_lp
  from `gr-datalake-prod.prod_stg_google_analytics_4_core.dim_ga4__sessions_daily` group by 1
),
s as (
  select s.session_start_date as ssd, s.count_purchase as conv, s.sum_event_value_in_usd as rev,
    s.session_utm_id as camp_before,                                            -- current prod
    regexp_extract(coalesce(c.complete_lp, s.landing_page), r'utm_id=([^&|\?|#]*)') as camp_after  -- fix
  from `gr-datalake-prod.prod_marts.ga4__sessions` s
  left join clp c on c.session_key = s.session_key
  where s.count_purchase > 0
),
bef as (
  select format_date('%Y-%m', s.ssd) as month, sum(s.conv) as c, round(sum(s.rev),0) as r
  from s inner join paid p on p.campaign_id = s.camp_before and p.date_day = s.ssd group by 1
),
aft as (
  select format_date('%Y-%m', s.ssd) as month, sum(s.conv) as c, round(sum(s.rev),0) as r
  from s inner join paid p on p.campaign_id = s.camp_after and p.date_day = s.ssd group by 1
)
select coalesce(bef.month, aft.month) as month,
  coalesce(bef.c,0) as sess_conv_before, coalesce(aft.c,0) as sess_conv_after,
  coalesce(aft.c,0)-coalesce(bef.c,0) as conv_delta,
  coalesce(bef.r,0) as sess_rev_before, coalesce(aft.r,0) as sess_rev_after
from bef full outer join aft using (month) order by 1;
```

**Monthly full-history reconciliation — paid campaigns, conversions (before = live prod):**

| month   | session_before | session_after | Δ session | lnd_before | lnd_after | Δ lnd |
|---------|---------------:|--------------:|----------:|-----------:|----------:|------:|
| 2023-06 | 40    | 40    | 0    | 40    | 40    | 0   |
| 2023-07 | 674   | 674   | 0    | 671   | 699   | +28 |
| 2023-08 | 741   | 741   | 0    | 728   | 773   | +45 |
| 2023-09 | 445   | 445   | 0    | 441   | 468   | +27 |
| 2023-10 | 383   | 383   | 0    | 382   | 418   | +36 |
| 2023-11 | 608   | 608   | 0    | 596   | 661   | +65 |
| 2023-12 | 751   | 751   | 0    | 743   | 848   | +105 |
| 2024-01 | 850   | 850   | 0    | 847   | 957   | +110 |
| 2024-02 | 839   | 839   | 0    | 835   | 964   | +129 |
| 2024-03 | 443   | 443   | 0    | 443   | 499   | +56 |
| 2024-06 | 6     | 6     | 0    | 6     | 6     | 0   |
| 2024-07 | 50    | 50    | 0    | 50    | 54    | +4  |
| 2024-08 | 37    | 37    | 0    | 37    | 40    | +3  |
| 2024-09 | 80    | 80    | 0    | 80    | 82    | +2  |
| 2024-10 | 73    | 73    | 0    | 72    | 82    | +10 |
| 2024-11 | 42    | 42    | 0    | 42    | 46    | +4  |
| 2024-12 | 12    | 12    | 0    | 12    | 13    | +1  |
| 2025-01 | 6     | 6     | 0    | 6     | 7     | +1  |
| 2025-02 | 224   | 224   | 0    | 224   | 256   | +32 |
| 2025-03 | 377   | 377   | 0    | 377   | 431   | +54 |
| 2025-04 | 477   | 477   | 0    | 476   | 536   | +60 |
| 2025-05 | 1,127 | 1,127 | 0    | 1,126 | 1,254 | +128 |
| 2025-06 | 1,510 | 1,510 | 0    | 1,507 | 1,701 | +194 |
| 2025-07 | 1,273 | 1,273 | 0    | 1,271 | 1,420 | +149 |
| 2025-08 | 1,542 | 1,542 | 0    | 1,539 | 1,739 | +200 |
| 2025-09 | 2,121 | 2,121 | 0    | 2,097 | 2,293 | +196 |
| 2025-10 | 2,033 | 2,033 | 0    | 2,004 | 2,201 | +197 |
| 2025-11 | 1,743 | 1,743 | 0    | 1,730 | 1,760 | +30 |
| 2025-12 | 2,794 | 2,794 | 0    | 2,767 | 2,826 | +59 |
| 2026-01 | 2,084 | 2,186 | +102 | 2,161 | 2,188 | +27 |
| 2026-02 | 1,213 | 1,381 | +168 | 1,369 | 1,399 | +30 |
| 2026-03 | 1,032 | 1,214 | +182 | 1,208 | 1,228 | +20 |
| 2026-04 | 1,123 | 1,308 | +185 | 1,300 | 1,333 | +33 |
| 2026-05 | 463   | 564   | +101 | 563   | 571   | +8  |
| 2026-06 | 266   | 313   | +47  | 309   | 320   | +11 |

Revenue moves in proportion (run the queries above for the `*_rev_*` columns); e.g. 2026-05
session revenue $104,553 → $126,816 and LND revenue $126,632 → $127,210.

**Filled validation checklist:**

1. [x] Environment alignment: single project `gr-datalake-prod`, USD, GA4 session grain on both sides.
2. [x] Technical filter sync: `(direct)` exclusion and `count_purchase`/`purchase_count > 0` applied identically before/after.
3. [x] Reconciliation: "before" reproduction matches the live prod mart row-for-row across full history.
4. [x] Grain & fan-out check: LND lookback join 1:1 (260,666 = 260,666 distinct sessions, May).
5. [x] Historical completeness: monthly before/after deltas over the full mart history (table above).
6. [x] PR evidence: pasteable BigQuery SQL + monthly full-history table in body.

### Data impact

- Impacted outputs: `ga4__sessions` (new `landing_page_location` column; corrected `session_utm_id`/
  `session_ad_id`/`session_ad_group_id`), `paid_ads__campaign_report_enriched`
  (`ga4_session_conversions`, `ga4_session_revenue`, `ga4_last_non_direct_conversions`,
  `ga4_last_non_direct_revenue`), `paid_ads__ad_report_enriched` (same metric set). Any
  downstream dashboards on these marts update on next refresh.
- Direction and magnitude: **up.** Session conversions ~0% before 2026, then +8–18%/month in
  2026 (the undercount window). LND conversions up ~2–13%/month across all history. Revenue
  moves in proportion.
- Effective window: retroactive across the full mart history once these are table-materialized
  models and rebuilt. The **session** uplift is effectively 2026-01-onward (pre-2026 delta = 0);
  the **LND** correction applies to all history.
- Non-updated history: none frozen — all three are full-refresh `table` models, so a normal
  build restates history.
- Why: (1) LND was crediting the converting session's own UTM instead of the last-non-direct
  touch; (2) session UTM parsing dropped any session whose first event had no `page_location`.

### Discrepancies (dev vs prod) and explanation

**Discrepancy 1: session-conversion undercount is the headline change (not a defect introduced here)**

- What differs: `ga4_session_conversions` for paid campaigns rises +100–185/month from 2026-01
  (e.g. 2026-05 463 → 564). Pre-2026 months are unchanged (delta 0).
- Root cause: `ga4__sessions.session_utm_id = REGEXP_EXTRACT(landing_page, 'utm_id=…')`, and
  `landing_page` is `NULL` for ~6,372 of 8,155 May purchase-sessions (the first qualifying event
  often carries no `page_location` since ~2026-01). Null UTM → the purchase can't match its paid
  campaign and is dropped. The fix parses from a complete landing page
  (`FIRST_VALUE(page_location IGNORE NULLS)`), recovering ~409 of those sessions.
- Evidence: diagnostic on `prod_marts.ga4__sessions` (May): `stored_utm_null = 6,372`,
  `complete_utm_null = 5,963`; `conv_stored = 471` vs `conv_from_complete = 572`. Reproduced in
  SQL #2 above; "before" matches prod row-for-row.
- Classification: **Bug fixed in PR.**
- Next step: none.

**Discrepancy 2: LND "before" was numerically close to session "after" by coincidence**

- What differs: pre-fix, LND conversions (e.g. May 563) happened to sit near the *corrected*
  session number (564), which originally looked like "LND > session" working as intended.
- Root cause: the old LND CTE read the converting session's own `landing_page_location` (the
  daily dim, which is already complete), so it was effectively a *more-complete session* metric,
  not true last-non-direct. The fix moves it to the prior touch's landing page; the number
  changes only modestly (May 563 → 571) but is now correct by construction.
- Evidence: SQL #1 above; `lnd_conv_before` matches the prod mart row-for-row, `after` follows
  the lookback pointer.
- Classification: **Bug fixed in PR.**
- Next step: none.

**Discrepancy 3: 2026-06 "before" off by ~2 conversions vs the stored mart**

- What differs: 2026-06 session_before = 266 vs the stored mart's 264 (LND identical at 309).
- Root cause: live source tables have advanced since the mart was last built (2026-06 is an open
  month); the reconciliation reads live `prod_marts.ga4__sessions` / daily tables.
- Evidence: `max(session_start_date)` on `prod_marts.ga4__sessions` = 2026-06-09 vs the mart's
  last build.
- Classification: **Expected** (open-month data drift).
- Next step: none; closed months match exactly.

**Discrepancy 4: dev build is lower than prod for 2026-03 → 2026-06**

- What differs: in the dev build, recent months fall below prod (e.g. 2026-05 dev session 55 vs
  prod 463; 2026-06 dev empty). Both session and LND drop together.
- Root cause: a **dev-build data-freshness artifact**, not the patch. `ga4__sessions` is a full
  refresh that reads `stg_ga4__events`; the deferred prod source is incomplete for the most
  recent weeks, so `dev_marts.ga4__sessions` maxes at **2026-05-18** vs prod **2026-06-09** (and
  is sparse for the weeks before). Months with complete source data reconcile to the row.
- Evidence: `max(session_start_date)`: `dev_marts.ga4__sessions` = 2026-05-18,
  `prod_marts.ga4__sessions` = 2026-06-09; build warned `date_day` is >3 days old.
- Classification: **Expected** (local dev source lag; scheduled dbt Cloud runs against complete
  data are unaffected).
- Next step: re-confirm the recent-month uplift in CI/dbt Cloud once a full scheduled build runs.

## Self-review notes (AI-assisted PR)

- Column names verified against `INFORMATION_SCHEMA` (`landing_page_location`,
  `session_partition_key_last_non_direct`, `purchase_count`,
  `session_partition_sum_event_value_in_usd`).
- No business filters added in staging; staging models read unchanged.
- IDs kept as STRING; `utm_id`/`ad_id`/`ad_group_id` parsed via the existing
  `get_query_parameter_value` macro (no new casting assumptions).
- No mart renamed; no new `not_null`/`unique` tests added beyond the existing project
  convention (this package ships no column-level tests today — see follow-up).

## Follow-ups (not blocking)

- A local `dbt build` on GR's **dev** target has been run (deps via a temporary `local:` override
  of this package, upstreams deferred to prod): all three models compiled, built, and passed
  tests, and dev-vs-prod reconciled to the row on every complete-source month. The remaining gate
  is a normal **dbt Cloud / CI** run against complete recent data to confirm the 2026-03→06
  uplift (see Discrepancy 4).
- `session_landing_lookup` scans the full daily dim each build; consider an incremental/bounded
  lookback (`session_attribution_lookback_window_days`) if build cost grows.
